### PR TITLE
Include username and WIF as elements

### DIFF
--- a/upvote_slider.html
+++ b/upvote_slider.html
@@ -2,10 +2,14 @@
 <head><title>Upvote-Downvote Slider </title>
 <h1></h1>
 <p></p>
+Your Username:<br>
+<input type="text" id=voter size=100><br>
+Your Posting Key:<br>
+<input type="text" id=wif size=100><br>
 Link:<br>
 <input type="text" id="link" size=100><br>
 
--100 <input type="range" id=voter min="-100" max="100" step="0.5"      
+-100 <input type="range" id=weight min="-100" max="100" step="0.5"      
 onchange="showValue(this.value)" /> 100
 <br><span id="value">Vote Value : 0<br /></span>
 <br><br />
@@ -29,28 +33,21 @@ onchange="showValue(this.value)" /> 100
 
 <script src="https://explore.smoke.io/assets/smokejs.min.js"></script>
 <script language="JavaScript">
-
-
 steem.api.setOptions({ url: 'ws://104.248.168.86:8090/' });
-
 // Function to see the value of the slider
 function showValue(newValue)
 {
 document.getElementById("value").innerHTML="Vote Value : "+newValue+"<br />";
 }
-
 // vote sending function
 function send_vote(){
 var link;
 var user;
 var permlink;
-
-var posting_wif= "Your posting WIF"; //enter your posting key here, not the active key or user key-only posting key
-var voter="your Smoke user name"; // your name will be here - without @ sign
-
-var weight=document.getElementById("voter").value*100;// put the voting weight in the variable
+var weight=document.getElementById("weight").value*100;// put the voting weight in the variable
 link =document.getElementById("link").value;//get the url from the textbox
-
+voter =document.getElementById("voter").value;
+posting_wif =document.getElementById("wif").value;
 var perm = link.split("/");//split the url to get permlink and user
 var length_perm=perm.length;
 permlink=perm[length_perm-1];//the permlink is the last element after "/" sign 
@@ -69,7 +66,7 @@ steem.broadcast.vote(posting_wif, voter, user, permlink, weight, function(err, r
 <body>
 
 <div class="footer">
-<p>Vote @mister-meeseeks for Witness! </p>
+<p>Vote @mister-meeseeks & @trees for Witness! </p>
 </div>
 
 </body>


### PR DESCRIPTION
If you include the username and wif as text input then you can host it somewhere like IPFS and let people use it from there.
Such as https://ipfs.io/ipfs/QmPNAkTU1vwVaXS55CrPzCWj6wNW14PpKVZTiQfAp71bma
Then to use it on a mobile device they just have to go to the link.
How can we obfuscate the wif so it's not on the screen?